### PR TITLE
Rename label 'BVGS Approved & Tested' to 'In Active Use by BvGS Members'

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The file `data.yml` includes all the information about the tools and the categor
 Every tool is part of one category. By using the field `second_path`, a tool can be displayed in more than one category.
 The available fields are explained [here](https://github.com/cncf/landscape2/blob/main/docs/config/data.yml).
 
-The field `project` is not used to specify the maturity in the sense of the CNCF, but if we, the Bundesverband Green Software, have successfully field-tested the tool/project. If that is the case, the field is set to: `project: "approved+tested"`
+The field `project` is not used to specify the maturity in the sense of the CNCF. Instead, we use it to highlight tools that are used in practice by member organiations of the Bundesverband Green Software. If that is the case, the field is set to: `project: "in-active-use-by-members"`
 
 Logos are placed in the [logos](./logos/) directory. If there is no logo available, we either use the logo of the organization behind the project (subfolder [organization](./logos/organization/)) or we generate a basic text only image (subfolder [unofficial](./logos/unofficial/)). We used the tool [Text-SVG-Generator](https://text-to-svg.com/) to generate some logos and used the font "Impact".
 

--- a/data.yml
+++ b/data.yml
@@ -58,7 +58,7 @@ categories:
             homepage_url: https://www.li10.com/
             docs: https://www.li10.com/#docs
             logo: li10.svg
-            project: "approved+tested"
+            project: "in-active-use-by-members"
 
           - item:
             name: Boavizta Cloud-Scanner for AWS
@@ -132,7 +132,7 @@ categories:
             homepage_url: https://sustainable-computing.io/
             repo_url: https://github.com/sustainable-computing-io/kepler
             logo: kepler.svg
-            project: "approved+tested"
+            project: "in-active-use-by-members"
 
           - item:
             name: KEIT
@@ -159,7 +159,7 @@ categories:
             docs: https://hubblo-org.github.io/scaphandre-documentation/index.html
             repo_url: https://github.com/hubblo-org/scaphandre
             logo: scaphandre.svg
-            project: "approved+tested"
+            project: "in-active-use-by-members"
 
           - item:
             name: CEEMS
@@ -207,7 +207,7 @@ categories:
             blog: https://www.green-coding.io/blog/
             repo_url: https://github.com/green-coding-solutions/green-metrics-tool
             logo: green-metrics-tool.png
-            project: "approved+tested"
+            project: "in-active-use-by-members"
             second_path:
               - "Website / Website Energy Measurement"
 
@@ -250,7 +250,7 @@ categories:
             docs: https://github.com/green-coding-solutions/hog/blob/main/README.md#the-power-hog
             repo_url: https://github.com/green-coding-solutions/hog/
             logo: power-hog.png
-            project: "approved+tested"
+            project: "in-active-use-by-members"
 
           - item:
             name: Watt Wiser
@@ -273,7 +273,7 @@ categories:
             description: A proprietary solution for measuring the energy efficiency and carbon footprint of websites and mobile applications on real devices on the test bench of Greenspector.
             homepage_url: https://greenspector.com/en/greenspector-studio-it-environmental-footprint-websites-applications/
             logo: greenspector.png
-            project: "approved+tested"
+            project: "in-active-use-by-members"
             second_path:
               - "Website / Website Energy Measurement"
 
@@ -331,7 +331,7 @@ categories:
             homepage_url: https://codecarbon.io/
             repo_url: https://github.com/mlco2/codecarbon
             logo: codecarbon.jpg
-            project: "approved+tested"
+            project: "in-active-use-by-members"
             second_path:
               - "Artificial Intelligence / AI Model Training"
 
@@ -349,7 +349,7 @@ categories:
             homepage_url: https://www.oaklean.io/
             repo_url: https://github.com/hitabisgmbh/oaklean
             logo: oaklean.svg
-            project: "approved+tested"
+            project: "in-active-use-by-members"
             
           - item:
             name: perun
@@ -419,7 +419,7 @@ categories:
             homepage_url: https://www.green-coding.io/products/eco-ci/
             repo_url: https://github.com/green-coding-solutions/eco-ci-energy-estimation
             logo: eco-ci.png
-            project: "approved+tested"
+            project: "in-active-use-by-members"
 
   - name: Artificial Intelligence
     subcategories:
@@ -545,7 +545,7 @@ categories:
             docs: https://doc.api.boavizta.org/
             repo_url: https://github.com/Boavizta/boaviztapi
             logo: boaviztapi.svg
-            project: "approved+tested"
+            project: "in-active-use-by-members"
 
           - item:
             name: Climatiq
@@ -571,7 +571,7 @@ categories:
             description: CarbonDB collects and consolidates energy usage data from multiple sources within a company, providing a unified view of energy consumption. It accurately converts energy usage into carbon emissions, enabling precise tracking of a company's carbon footprint.
             homepage_url: https://www.green-coding.io/products/carbondb/
             logo: carbondb.png
-            project: "approved+tested"
+            project: "in-active-use-by-members"
 
           - item:
             name: fruggr
@@ -717,7 +717,7 @@ categories:
             homepage_url: https://www.green-coding.io/products/cloud-energy/
             repo_url: https://github.com/green-coding-solutions/cloud-energy
             logo: cloud-energy.png
-            project: "approved+tested"
+            project: "in-active-use-by-members"
 
           - item:
             name: EnergiBridge
@@ -748,7 +748,7 @@ categories:
             repo_url: https://github.com/thegreenwebfoundation/co2.js
             logo: unofficial/CO2.js.svg
             license: "Apache-2.0"
-            project: "approved+tested"
+            project: "in-active-use-by-members"
 
           - item:
             name: Website Carbon Calculator
@@ -761,7 +761,7 @@ categories:
             description: Ecograder analyzes websites for environmental impact by evaluating performance, design, development practices, and hosting, offering insights and recommendations to improve digital sustainability. A badge is provided that can be added to the footer of websites.
             homepage_url: https://ecograder.com/
             logo: ecograder.svg
-            project: "approved+tested"
+            project: "in-active-use-by-members"
             second_path:
               - "Website / Website Analysis"
 
@@ -915,7 +915,7 @@ categories:
             homepage_url: https://keda.sh/
             repo_url: https://github.com/kedacore/keda
             logo: keda.png
-            project: "approved+tested"
+            project: "in-active-use-by-members"
 
           - item:
             name: Goldilocks
@@ -932,7 +932,7 @@ categories:
             docs: https://karpenter.sh/docs/
             repo_url: https://github.com/aws/karpenter
             logo: karpenter.svg
-            project: "approved+tested"
+            project: "in-active-use-by-members"
 
           - item:
             name: Compute Gardener Scheduler
@@ -947,7 +947,7 @@ categories:
             homepage_url: https://kube-green.dev/
             repo_url: https://github.com/kube-green/kube-green
             logo: kube-green.svg
-            project: "approved+tested"
+            project: "in-active-use-by-members"
 
           - item:
             name: DailyClean
@@ -981,7 +981,7 @@ categories:
             homepage_url: https://carbon-aware-sdk.greensoftware.foundation/
             repo_url: https://github.com/Green-Software-Foundation/carbon-aware-sdk
             logo: carbon-aware-sdk.png
-            project: "approved+tested"
+            project: "in-active-use-by-members"
 
           - item:
             name: grid-intensity-go
@@ -996,7 +996,7 @@ categories:
             homepage_url: https://github.com/envite-consulting/camunda-carbon-reductor
             repo_url: https://github.com/envite-consulting/camunda-carbon-reductor
             logo: camunda-carbon-reductor.svg
-            project: "approved+tested"
+            project: "in-active-use-by-members"
 
           - item:
             name: Carbon-Aware-Computing.com
@@ -1007,7 +1007,7 @@ categories:
             homepage_url: https://carbon-aware-computing.com/
             repo_url: https://github.com/bluehands/Carbon-Aware-Computing
             logo: unofficial/Carbon-Aware-Computing.com.svg
-            project: "approved+tested"
+            project: "in-active-use-by-members"
             second_path:
               - "Databases / Grid Carbon Intensity API Service"
 

--- a/guide.yml
+++ b/guide.yml
@@ -34,10 +34,10 @@ categories:
           Wenn ein Tool in mehrere Kategorien passt, wird es entsprechend mehrfach dargestellt.
           Mittels der Filter-Funktion links oben können Kategorien gefiltert werden.
 
-      - subcategory: "Kennzeichnung 'BVGS Approved & Tested'"
+      - subcategory: "Kennzeichnung 'In Active Use by BvGS Members'"
         content: |
 
-          Einzelne Tools werden mit der Kennzeichnung 'BVGS Approved & Tested' hervorgehoben, die unserer Erfahrung nach für einen praktischen Einsatz geeignet sind. Ob ein Tool die Kennzeichnung erhält entscheidet der BVGS-Arbeitskreis "Tools & Messverfahren". Das wesentliche Kriterium hierfür ist, ob mindestens ein Mitglied im Bundesverband das Tool erfolgreich im praktischen Einsatz erprobt und getested hat und für hilfreich befunden hat.
+          Einzelne Tools sind mit der Kennzeichnung 'In Active Use by BvGS Members' hervorgehoben. Wir kennzeichnen damit die Tools, die von den Mitgliedsorganisationen des Bundesverbands Green Software in der Praxis im Einsatz sind. Es handelt sich hierbei um kein Qualitätssiegel.
           
       - subcategory: "Kennzeichnung 'Archived'"
         content: |
@@ -75,11 +75,11 @@ categories:
           If a tool fits into several categories, it is displayed several times.
           Categories can be filtered using the filter function at the top left.
 
-      - subcategory: "Label 'BVGS Approved & Tested'"
+      - subcategory: "Label 'In Active Use by BvGS Members'"
         content: |
 
-          Individual tools are highlighted with the 'BVGS Approved & Tested' label, which in our experience are suitable for practical use. The BVGS working group "Tools & Measurement Methods" decides whether a tool receives the label. The main criterion for this is whether at least one member of the association has successfully tried and tested the tool in practical use and found it to be helpful.
-          
+          Individual tools are highlighted with the label 'In Active Use by BvGS Members'. We use this label to highlight tools that are used in practice by member organisations of the Bundesverband Green Software. This is not a seal of quality.          
+
       - subcategory: "Label 'Archived'"
         content: |
 

--- a/settings.yml
+++ b/settings.yml
@@ -29,9 +29,9 @@ colors:
 featured_items:
   - field: maturity
     options:
-      - value: approved+tested
+      - value: in-active-use-by-members
         order: 1
-        label: BVGS Approved & Tested
+        label: In Active Use by BvGS Members
 
 footer:
   links:


### PR DESCRIPTION
As discussed in todays working group meeting, we want to rename the label 'BVGS Approved & Tested'. The goal is to make clear what the label means: it is in active use by at least one member organization of the Bundesverband Green Software.

In the meeting we proposed the label 'In Active Use by Member'.
I changed it in this PR a little bit to 'In Active Use by BvGS Members'. Let me know what you think.

@ArneTR @glatzg @Lizard0

## Screenshots

<img width="2534" height="1269" alt="image" src="https://github.com/user-attachments/assets/fb1351b3-4543-48cc-811c-9ffe84623031" />

<img width="2478" height="819" alt="image" src="https://github.com/user-attachments/assets/ba08ffc0-a6a8-4b3d-9e5b-5cd0af6411e7" />

<img width="1369" height="689" alt="image" src="https://github.com/user-attachments/assets/eecfe71d-db1b-4349-b6e4-12bd1936d58c" />

<img width="2082" height="334" alt="image" src="https://github.com/user-attachments/assets/49dfcc58-2d5f-4318-9727-df247e01206d" />
