### PR TITLE
Move OxygenIT to Databases category

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -584,6 +584,16 @@ categories:
             homepage_url: https://resilio-solutions.com/en/services/database
             logo: resilio-database.svg
 
+          - item:
+            name: OxygenIT
+            description: OxygenIT provides GreenOps APIs for estimating energy and carbon emissions from IaaS, DBaaS, and PaaS cloud services, as well as on-premises bare metal and laptop/desktops hardware. The enterprise version can also provide optimization suggestions.
+            homepage_url: https://www.oxygenit.io/
+            logo: oxygenit.png
+            second_path:
+              -  "Optimization / Cloud Infrastructure"
+            extra:
+              documentation_url: https://docs.oxygenit.io/
+
   - name: Data Aggregation
     subcategories:
 
@@ -891,14 +901,6 @@ categories:
             description: A platform for analyzing and optimizing cloud infrastructure for cost and sustainability.
             homepage_url: https://txture.io/
             logo: txture.png
-            second_path:
-              -  "Infrastructure & Cluster Level / Infrastructure Provider Level"
-
-          - item:
-            name: OxygenIT
-            description: A solution for optimizing IT infrastructure to reduce energy consumption and carbon emissions.
-            homepage_url: https://www.oxygenit.io/
-            logo: oxygenit.png
             second_path:
               -  "Infrastructure & Cluster Level / Infrastructure Provider Level"
 


### PR DESCRIPTION
As [OxygenIT](https://www.oxygenit.io/product-pages/the-greenops-api) is now an API-only service, I think it would makes sense to move it to the "Databases" category:

<img width="639" height="472" alt="{E13C7AC8-E9C7-42A9-A524-DB5096B29EFD}" src="https://github.com/user-attachments/assets/c197d047-b483-4d45-b4fe-9139a3234853" />
