### PR TITLE
Update tools with label in-active-use-by-members

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -30,6 +30,7 @@ categories:
             description: Power BI App that provides emissions for azure cloud resource usage.
             homepage_url: https://marketplace.microsoft.com/en-us/product/power-bi/coi-sustainability.emissions_impact_dashboard
             logo: azure-impact-dashboard.png
+            project: "in-active-use-by-members"
             extra:
               documentation_url: https://learn.microsoft.com/en-us/power-bi/connect-data/service-connect-to-emissions-impact-dashboard
 
@@ -38,6 +39,7 @@ categories:
             description: The Carbon Footprint dashboard displays estimated greenhouse gas emissions associated with the usage of covered Google Cloud services for the selected billing account.
             homepage_url: https://cloud.google.com/carbon-footprint
             logo: google-cloud.svg
+            project: "in-active-use-by-members"
             extra:
               documentation_url: https://cloud.google.com/carbon-footprint#documentation
 
@@ -46,6 +48,7 @@ categories:
             description: The AWS Customer Carbon Footprint Tool provides estimates of the carbon emissions associated with AWS products and services. Data is updated with a delay of three months.
             homepage_url: https://aws.amazon.com/sustainability/tools/aws-customer-carbon-footprint-tool/
             logo: aws.svg
+            project: "in-active-use-by-members"
             extra:
               documentation_url: https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/what-is-ccft.html
 
@@ -206,6 +209,7 @@ categories:
             homepage_url: https://datavizta.boavizta.org/
             repo_url: https://github.com/Boavizta/datavizta
             logo: datavizta.svg
+            project: "in-active-use-by-members"
 
           - item:
             name: EasyVirt Eclyo
@@ -243,6 +247,7 @@ categories:
             description: This little script enables you to see when it is worth replacing an old machine with a new one.
             homepage_url: https://hardware-checker.green-coding.io/
             logo: unofficial/hardware-replacement-calculator.svg
+            project: "in-active-use-by-members"
 
           - item:
             name: Technology Carbon Estimator
@@ -373,6 +378,7 @@ categories:
             homepage_url: https://github.com/msg-systems/jpowermonitor
             repo_url: https://github.com/msg-systems/jpowermonitor
             logo: unofficial/jPowerMonitor.svg
+            project: "in-active-use-by-members"
 
           - item:
             name: DotNet-Counters
@@ -393,7 +399,6 @@ categories:
             homepage_url: https://codecarbon.io/
             repo_url: https://github.com/mlco2/codecarbon
             logo: codecarbon.jpg
-            project: "in-active-use-by-members"
             second_path:
               - "Artificial Intelligence / AI Model Training"
               - "Device & Process Level / Device Measurement"
@@ -744,6 +749,7 @@ categories:
             homepage_url: https://github.com/ColinIanKing/powerstat
             repo_url: https://github.com/ColinIanKing/powerstat
             logo: powerstat.png
+            project: "in-active-use-by-members"
 
           - item:
             name: Perf
@@ -751,6 +757,7 @@ categories:
             homepage_url: https://perf.wiki.kernel.org/index.php/Main_Page
             repo_url: https://web.git.kernel.org/pub/scm/linux/kernel/git/perf/perf-tools-next.git/
             logo: unofficial/perf.svg
+            project: "in-active-use-by-members"
 
           - item:
             name: Turbostat
@@ -779,6 +786,7 @@ categories:
             homepage_url: https://github.com/fenrus75/powertop
             repo_url: https://github.com/fenrus75/powertop
             logo: unofficial/PowerTOP.svg
+            project: "in-active-use-by-members"
 
           - item:
             name: Cloud Energy
@@ -873,13 +881,13 @@ categories:
             description: Website Carbon Calculator estimates the carbon emissions of a website by analyzing factors like data transfer size and energy source of the hosting provider. A badge is provided that can be added to the footer of websites.
             homepage_url: https://www.websitecarbon.com/
             logo: WebsiteCarbon.jpg
+            project: "in-active-use-by-members"
 
           - item:
             name: Ecograder
             description: Ecograder analyzes websites for environmental impact by evaluating performance, design, development practices, and hosting, offering insights and recommendations to improve digital sustainability. A badge is provided that can be added to the footer of websites.
             homepage_url: https://ecograder.com/
             logo: ecograder.svg
-            project: "in-active-use-by-members"
             second_path:
               - "Website / Website Analysis"
 
@@ -911,6 +919,7 @@ categories:
             homepage_url: https://github.com/bluehands/Website-Carbon-Meter
             repo_url: https://github.com/bluehands/Website-Carbon-Meter
             logo: unofficial/website-carbon-meter.svg
+            project: "in-active-use-by-members"
 
       - name: Website Energy Measurement
         items:
@@ -1070,7 +1079,6 @@ categories:
             homepage_url: https://kube-green.dev/
             repo_url: https://github.com/kube-green/kube-green
             logo: kube-green.svg
-            project: "in-active-use-by-members"
 
           - item:
             name: DailyClean


### PR DESCRIPTION
We did a survey inside the Bundesverband Green Software which tools are in active use.

This PR updates the labels based on the results of the survey.

## Questions

For me there are two open questions:

1. What about tools that are developed by a member organization but are not used actively (yet) by other member organizations? Is it ok that it is used internally by them? Tools:
    - oaklean (Hitabis)
    - CarbonDB (GCS)
    - Cloud Energy (GCS)
    - Power Hog (GCS)
    - Camunda Carbon Reductor (envite)
    - Website Carbon Meter (bluehands)
    - Carbon-Aware-Computing.com (bluehands)
2. What about the dashboards from cloud providers? Based on the survey, only the dashboards of the hyperscalers are used (AWS, Azure, Google). Dashboards from other cloud providers, like Scaleway and OVHcloud, are not used. The obvious reason is that the organization that answered the survey are (only) using the hyperscalers at the moment. 

## Screenshots

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7ec7f9ab-e3b5-4736-8315-3231797c7fe9" />

<img width="1908" height="1073" alt="image" src="https://github.com/user-attachments/assets/268f5083-395e-42af-abef-0c3aa047d28a" />

<img width="1913" height="632" alt="image" src="https://github.com/user-attachments/assets/c02ce8dc-ab91-48b6-a845-6914e8c94a20" />
